### PR TITLE
Fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ A full example with all available options and example values is provided below.
 | `pr-threshold`           | An `Integer` based on which `action-jira-linter` will add a comment discouraging huge PRs.                                                                                                                                                                     |          | `800`           |
 | `validate-issue-status`  | A `Boolean` based on which `action-jira-linter` will validate the status of the detected jira issue                                                                                                                                                            |          | `false`         |
 | `allowed-issue-statuses` | A line-separated list of acceptable Jira issue statuses. The detected jira issue's status will be compared against this list and if a match is not found then the status check will fail. _Note_: Requires `validate-issue-status` to be set to `true`. |          | `'In Progress'` |
-| `fail-on-error`          | A `Boolean` which, if set to `true`, fails the GitHub Action when an error occurs. Default `true`.                                                                                                                                                      |          | `false`         |
+| `fail-on-error`          | A `Boolean` which, if set to `true`, fails the GitHub Action when an error occurs. Default `true`.                                                                                                                                                      |          | `true`         |
 
 **Special note on `jira-token`:** Since tokens are private, we suggest adding
 them as [GitHub secrets][secrets].


### PR DESCRIPTION
The text says the default is true, but the next column disagrees. Bring these into alignment